### PR TITLE
feat: Implement user roles and category management

### DIFF
--- a/inventory-management-system-backend/src/main/java/com/bluepal/config/ApplicationConfiguration.java
+++ b/inventory-management-system-backend/src/main/java/com/bluepal/config/ApplicationConfiguration.java
@@ -27,7 +27,7 @@ public class ApplicationConfiguration {
 
 						.requestMatchers("/api/user/profile","/api/user/all","/products/all")
 						.hasAnyRole("USER", "ADMIN")
-						.requestMatchers("/products/add","/products/update/{id}","/products/delete/{id}","/sales/all","/reports/*").hasRole("ADMIN")
+						.requestMatchers("/products/add","/products/update/{id}","/products/delete/{id}","/sales/all","/reports/*", "/api/categories/**").hasRole("ADMIN")
 						.requestMatchers( "/api/products/my-products","/sales/record").hasRole("USER")
 								
 						

--- a/inventory-management-system-backend/src/main/java/com/bluepal/controller/CategoryController.java
+++ b/inventory-management-system-backend/src/main/java/com/bluepal/controller/CategoryController.java
@@ -1,0 +1,56 @@
+package com.bluepal.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.bluepal.model.Category;
+import com.bluepal.service.CategoryService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/categories")
+public class CategoryController {
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @GetMapping
+    public List<Category> getAllCategories() {
+        return categoryService.getAllCategories();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Category> getCategoryById(@PathVariable String id) {
+        return categoryService.getCategoryById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Category> addCategory(@Valid @RequestBody Category category) {
+        return new ResponseEntity<>(categoryService.addCategory(category), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Category> updateCategory(@PathVariable String id, @Valid @RequestBody Category category) {
+        return new ResponseEntity<>(categoryService.updateCategory(id, category), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteCategory(@PathVariable String id) {
+        categoryService.deleteCategory(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/inventory-management-system-backend/src/main/java/com/bluepal/dto/AuthResponse.java
+++ b/inventory-management-system-backend/src/main/java/com/bluepal/dto/AuthResponse.java
@@ -11,4 +11,5 @@ public class AuthResponse {
 	 private String jwt;
 	 private String message;
 	 private Boolean status;
+	 private String role;
 }

--- a/inventory-management-system-backend/src/main/java/com/bluepal/model/Category.java
+++ b/inventory-management-system-backend/src/main/java/com/bluepal/model/Category.java
@@ -1,0 +1,22 @@
+package com.bluepal.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "categories")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category {
+
+    @Id
+    private String id;
+
+    @NotBlank(message = "Category name is required")
+    private String name;
+}

--- a/inventory-management-system-backend/src/main/java/com/bluepal/repository/CategoryRepository.java
+++ b/inventory-management-system-backend/src/main/java/com/bluepal/repository/CategoryRepository.java
@@ -1,0 +1,9 @@
+package com.bluepal.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import com.bluepal.model.Category;
+
+public interface CategoryRepository extends MongoRepository<Category, String> {
+
+}

--- a/inventory-management-system-backend/src/main/java/com/bluepal/service/AuthService.java
+++ b/inventory-management-system-backend/src/main/java/com/bluepal/service/AuthService.java
@@ -44,6 +44,7 @@ public class AuthService {
 
 
         user.setPassword(passwordEncoder.encode(user.getPassword()));
+        user.setRole("ROLE_USER");
         return userRepository.save(user);
     }
     
@@ -56,10 +57,13 @@ public class AuthService {
         String token = jwtProvider.generateToken(authentication);
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
 
+        String role = authorities.stream().findFirst().get().getAuthority();
+
         AuthResponse authResponse = new AuthResponse();
         authResponse.setJwt(token);
         authResponse.setMessage("Login Success");
         authResponse.setStatus(true);
+        authResponse.setRole(role);
      
 
         return authResponse;

--- a/inventory-management-system-backend/src/main/java/com/bluepal/service/CategoryService.java
+++ b/inventory-management-system-backend/src/main/java/com/bluepal/service/CategoryService.java
@@ -1,0 +1,38 @@
+package com.bluepal.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.bluepal.model.Category;
+import com.bluepal.repository.CategoryRepository;
+
+@Service
+public class CategoryService {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    public List<Category> getAllCategories() {
+        return categoryRepository.findAll();
+    }
+
+    public Optional<Category> getCategoryById(String id) {
+        return categoryRepository.findById(id);
+    }
+
+    public Category addCategory(Category category) {
+        return categoryRepository.save(category);
+    }
+
+    public Category updateCategory(String id, Category category) {
+        category.setId(id);
+        return categoryRepository.save(category);
+    }
+
+    public void deleteCategory(String id) {
+        categoryRepository.deleteById(id);
+    }
+}

--- a/inventory-management-system-frontend/src/components/common/Sidebar.jsx
+++ b/inventory-management-system-frontend/src/components/common/Sidebar.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { 
   Drawer, 
@@ -29,12 +30,24 @@ const menuItems = [
 function Sidebar() {
   const navigate = useNavigate();
   const location = useLocation();
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const { user } = useSelector((state) => state.auth);
 
-  const handleListItemClick = (index, path) => {
-    setSelectedIndex(index);
+  const handleListItemClick = (path) => {
     navigate(path);
   };
+
+  const filteredMenuItems = menuItems.filter((item) => {
+    if (item.path === '/products' || item.path === '/') {
+      return user && (user.role === 'ROLE_ADMIN' || user.role === 'ROLE_USER');
+    }
+    if (item.path === '/sales') {
+      return user && user.role === 'ROLE_USER';
+    }
+    if (item.path === '/reports') {
+      return user && user.role === 'ROLE_ADMIN';
+    }
+    return true;
+  });
 
   return (
     <Drawer
@@ -57,11 +70,11 @@ function Sidebar() {
       </Box>
       <Divider />
       <List>
-        {menuItems.map((item, index) => (
+        {filteredMenuItems.map((item, index) => (
           <ListItem key={item.text} disablePadding>
             <ListItemButton
               selected={location.pathname === item.path}
-              onClick={() => handleListItemClick(index, item.path)}
+              onClick={() => handleListItemClick(item.path)}
               sx={{
                 '&.Mui-selected': {
                   backgroundColor: 'rgba(255, 255, 255, 0.1)',

--- a/inventory-management-system-frontend/src/features/categories/categoryService.js
+++ b/inventory-management-system-frontend/src/features/categories/categoryService.js
@@ -1,0 +1,57 @@
+import axios from 'axios';
+
+const API_URL = 'http://localhost:8080/api/categories/';
+
+// Get all categories
+const getCategories = async (token) => {
+    const config = {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    };
+    const response = await axios.get(API_URL, config);
+    return response.data;
+};
+
+// Add category
+const addCategory = async (categoryData, token) => {
+    const config = {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    };
+    const response = await axios.post(API_URL, categoryData, config);
+    return response.data;
+};
+
+// Update category
+const updateCategory = async (id, categoryData, token) => {
+    const config = {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    };
+    const response = await axios.put(API_URL + id, categoryData, config);
+    return response.data;
+};
+
+// Delete category
+const deleteCategory = async (id, token) => {
+    const config = {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    };
+    const response = await axios.delete(API_URL + id, config);
+    return response.data;
+};
+
+
+const categoryService = {
+    getCategories,
+    addCategory,
+    updateCategory,
+    deleteCategory,
+};
+
+export default categoryService;

--- a/inventory-management-system-frontend/src/features/categories/categorySlice.js
+++ b/inventory-management-system-frontend/src/features/categories/categorySlice.js
@@ -1,0 +1,141 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import categoryService from './categoryService';
+
+const initialState = {
+    categories: [],
+    isError: false,
+    isSuccess: false,
+    isLoading: false,
+    message: '',
+};
+
+// Get all categories
+export const getCategories = createAsyncThunk('categories/getAll', async (_, thunkAPI) => {
+    try {
+        const token = thunkAPI.getState().auth.user.jwt;
+        return await categoryService.getCategories(token);
+    } catch (error) {
+        const message =
+            (error.response && error.response.data && error.response.data.message) ||
+            error.message ||
+            error.toString();
+        return thunkAPI.rejectWithValue(message);
+    }
+});
+
+// Add category
+export const addCategory = createAsyncThunk('categories/add', async (categoryData, thunkAPI) => {
+    try {
+        const token = thunkAPI.getState().auth.user.jwt;
+        return await categoryService.addCategory(categoryData, token);
+    } catch (error) {
+        const message =
+            (error.response && error.response.data && error.response.data.message) ||
+            error.message ||
+            error.toString();
+        return thunkAPI.rejectWithValue(message);
+    }
+});
+
+// Update category
+export const updateCategory = createAsyncThunk('categories/update', async (categoryData, thunkAPI) => {
+    try {
+        const token = thunkAPI.getState().auth.user.jwt;
+        return await categoryService.updateCategory(categoryData.id, categoryData, token);
+    } catch (error) {
+        const message =
+            (error.response && error.response.data && error.response.data.message) ||
+            error.message ||
+            error.toString();
+        return thunkAPI.rejectWithValue(message);
+    }
+});
+
+// Delete category
+export const deleteCategory = createAsyncThunk('categories/delete', async (id, thunkAPI) => {
+    try {
+        const token = thunkAPI.getState().auth.user.jwt;
+        return await categoryService.deleteCategory(id, token);
+    } catch (error) {
+        const message =
+            (error.response && error.response.data && error.response.data.message) ||
+            error.message ||
+            error.toString();
+        return thunkAPI.rejectWithValue(message);
+    }
+});
+
+export const categorySlice = createSlice({
+    name: 'categories',
+    initialState,
+    reducers: {
+        reset: (state) => {
+            state.isLoading = false;
+            state.isSuccess = false;
+            state.isError = false;
+            state.message = '';
+        },
+    },
+    extraReducers: (builder) => {
+        builder
+            .addCase(getCategories.pending, (state) => {
+                state.isLoading = true;
+            })
+            .addCase(getCategories.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.isSuccess = true;
+                state.categories = action.payload;
+            })
+            .addCase(getCategories.rejected, (state, action) => {
+                state.isLoading = false;
+                state.isError = true;
+                state.message = action.payload;
+            })
+            .addCase(addCategory.pending, (state) => {
+                state.isLoading = true;
+            })
+            .addCase(addCategory.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.isSuccess = true;
+                state.categories.push(action.payload);
+            })
+            .addCase(addCategory.rejected, (state, action) => {
+                state.isLoading = false;
+                state.isError = true;
+                state.message = action.payload;
+            })
+            .addCase(updateCategory.pending, (state) => {
+                state.isLoading = true;
+            })
+            .addCase(updateCategory.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.isSuccess = true;
+                state.categories = state.categories.map((category) =>
+                    category.id === action.payload.id ? action.payload : category
+                );
+            })
+            .addCase(updateCategory.rejected, (state, action) => {
+                state.isLoading = false;
+                state.isError = true;
+                state.message = action.payload;
+            })
+            .addCase(deleteCategory.pending, (state) => {
+                state.isLoading = true;
+            })
+            .addCase(deleteCategory.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.isSuccess = true;
+                state.categories = state.categories.filter(
+                    (category) => category.id !== action.payload
+                );
+            })
+            .addCase(deleteCategory.rejected, (state, action) => {
+                state.isLoading = false;
+                state.isError = true;
+                state.message = action.payload;
+            });
+    },
+});
+
+export const { reset } = categorySlice.actions;
+export default categorySlice.reducer;

--- a/inventory-management-system-frontend/src/pages/CategoriesPage.jsx
+++ b/inventory-management-system-frontend/src/pages/CategoriesPage.jsx
@@ -1,0 +1,182 @@
+import { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { toast } from 'react-toastify';
+import {
+    Container,
+    Typography,
+    Button,
+    Box,
+    Paper,
+    TextField,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    IconButton,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+} from '@mui/material';
+import {
+    Add as AddIcon,
+    Edit as EditIcon,
+    Delete as DeleteIcon,
+} from '@mui/icons-material';
+import { getCategories, addCategory, updateCategory, deleteCategory, reset } from '../features/categories/categorySlice';
+
+function CategoriesPage() {
+    const [showForm, setShowForm] = useState(false);
+    const [selectedCategory, setSelectedCategory] = useState(null);
+    const [name, setName] = useState('');
+    const dispatch = useDispatch();
+
+    const { categories, isLoading, isError, isSuccess, message } = useSelector(
+        (state) => state.categories
+    );
+
+    useEffect(() => {
+        dispatch(getCategories());
+
+        return () => {
+            dispatch(reset());
+        };
+    }, [dispatch]);
+
+    useEffect(() => {
+        if (isError) {
+            toast.error(message);
+        }
+    }, [isError, message]);
+
+    const handleAddCategory = () => {
+        setSelectedCategory(null);
+        setName('');
+        setShowForm(true);
+    };
+
+    const handleEditCategory = (category) => {
+        setSelectedCategory(category);
+        setName(category.name);
+        setShowForm(true);
+    };
+
+    const handleDeleteCategory = (id) => {
+        if (window.confirm('Are you sure you want to delete this category?')) {
+            dispatch(deleteCategory(id));
+        }
+    };
+
+    const handleCloseForm = () => {
+        setShowForm(false);
+        setSelectedCategory(null);
+        setName('');
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        if (selectedCategory) {
+            dispatch(updateCategory({ id: selectedCategory.id, name }));
+        } else {
+            dispatch(addCategory({ name }));
+        }
+        handleCloseForm();
+    };
+
+    return (
+        <Container maxWidth="xl">
+            <Box sx={{ mb: 4 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+                    <Typography variant="h4" component="h1">
+                        Categories
+                    </Typography>
+                    <Button
+                        variant="contained"
+                        startIcon={<AddIcon />}
+                        onClick={handleAddCategory}
+                    >
+                        Add Category
+                    </Button>
+                </Box>
+
+                <Typography variant="body1" color="text.secondary">
+                    Manage your product categories
+                </Typography>
+            </Box>
+
+            <Paper sx={{ width: '100%', overflow: 'hidden' }}>
+                <TableContainer sx={{ maxHeight: 600 }}>
+                    <Table stickyHeader aria-label="categories table">
+                        <TableHead>
+                            <TableRow>
+                                <TableCell>Name</TableCell>
+                                <TableCell>Actions</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {categories.map((category) => (
+                                <TableRow key={category.id}>
+                                    <TableCell component="th" scope="row">
+                                        {category.name}
+                                    </TableCell>
+                                    <TableCell>
+                                        <IconButton
+                                            aria-label="edit"
+                                            onClick={() => handleEditCategory(category)}
+                                            color="primary"
+                                        >
+                                            <EditIcon />
+                                        </IconButton>
+                                        <IconButton
+                                            aria-label="delete"
+                                            onClick={() => handleDeleteCategory(category.id)}
+                                            color="error"
+                                        >
+                                            <DeleteIcon />
+                                        </IconButton>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </Paper>
+
+            <Dialog
+                open={showForm}
+                onClose={handleCloseForm}
+                fullWidth
+                maxWidth="sm"
+            >
+                <DialogTitle>
+                    {selectedCategory ? 'Edit Category' : 'Add New Category'}
+                </DialogTitle>
+                <DialogContent>
+                    <Box component="form" onSubmit={handleSubmit} sx={{ mt: 1 }}>
+                        <TextField
+                            margin="normal"
+                            required
+                            fullWidth
+                            id="name"
+                            label="Category Name"
+                            name="name"
+                            autoFocus
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                        />
+                        <DialogActions>
+                            <Button onClick={handleCloseForm}>Cancel</Button>
+                            <Button type="submit" variant="contained">
+                                {selectedCategory ? 'Update' : 'Add'}
+                            </Button>
+                        </DialogActions>
+                    </Box>
+                </DialogContent>
+            </Dialog>
+        </Container>
+    );
+}
+
+export default CategoriesPage;

--- a/inventory-management-system-frontend/src/pages/ProductsPage.jsx
+++ b/inventory-management-system-frontend/src/pages/ProductsPage.jsx
@@ -44,6 +44,8 @@ function ProductsPage() {
     (state) => state.products
   );
 
+  const { user } = useSelector((state) => state.auth);
+
   useEffect(() => {
     dispatch(getProducts());
 
@@ -104,13 +106,15 @@ function ProductsPage() {
           <Typography variant="h4" component="h1">
             Products
           </Typography>
-          <Button 
-            variant="contained" 
-            startIcon={<AddIcon />}
-            onClick={handleAddProduct}
-          >
-            Add Product
-          </Button>
+          {user && user.role === 'ROLE_ADMIN' && (
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={handleAddProduct}
+            >
+              Add Product
+            </Button>
+          )}
         </Box>
         
         <Typography variant="body1" color="text.secondary">
@@ -174,20 +178,24 @@ function ProductsPage() {
                     </TableCell>
                     <TableCell>{product.threshold}</TableCell>
                     <TableCell>
-                      <IconButton 
-                        aria-label="edit" 
-                        onClick={() => handleEditProduct(product)}
-                        color="primary"
-                      >
-                        <EditIcon />
-                      </IconButton>
-                      <IconButton 
-                        aria-label="delete" 
-                        onClick={() => handleDeleteProduct(product.id)}
-                        color="error"
-                      >
-                        <DeleteIcon />
-                      </IconButton>
+                      {user && user.role === 'ROLE_ADMIN' && (
+                        <>
+                          <IconButton
+                            aria-label="edit"
+                            onClick={() => handleEditProduct(product)}
+                            color="primary"
+                          >
+                            <EditIcon />
+                          </IconButton>
+                          <IconButton
+                            aria-label="delete"
+                            onClick={() => handleDeleteProduct(product.id)}
+                            color="error"
+                          >
+                            <DeleteIcon />
+                          </IconButton>
+                        </>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/inventory-management-system-frontend/src/pages/ReportsPage.jsx
+++ b/inventory-management-system-frontend/src/pages/ReportsPage.jsx
@@ -46,6 +46,8 @@ function ReportsPage() {
     message,
   } = useSelector((state) => state.reports);
 
+  const { user } = useSelector((state) => state.auth);
+
   useEffect(() => {
     dispatch(getStockReport());
     dispatch(getDailySales());
@@ -75,6 +77,16 @@ function ReportsPage() {
 
   if (isLoading) {
     return <div>Loading reports...</div>;
+  }
+
+  if (user && user.role !== 'ROLE_ADMIN') {
+    return (
+      <Container maxWidth="xl">
+        <Typography variant="h4" component="h1" align="center" sx={{ mt: 4 }}>
+          You are not authorized to view this page.
+        </Typography>
+      </Container>
+    );
   }
 
   return (

--- a/inventory-management-system-frontend/src/pages/SalesPage.jsx
+++ b/inventory-management-system-frontend/src/pages/SalesPage.jsx
@@ -22,6 +22,7 @@ function SalesPage() {
     (state) => state.sales
   );
   const { products } = useSelector((state) => state.products);
+  const { user } = useSelector((state) => state.auth);
 
   useEffect(() => {
     dispatch(getSales());
@@ -51,29 +52,33 @@ function SalesPage() {
 
       <Grid container spacing={3}>
         {/* Sale Form */}
-        <Grid item xs={12} md={5}>
-          <Card sx={{ height: '100%' }}>
-            <CardContent>
-              <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-                <ShoppingCartIcon sx={{ mr: 1 }} />
-                <Typography variant="h6">Record New Sale</Typography>
-              </Box>
-              <SaleForm />
-            </CardContent>
-          </Card>
-        </Grid>
+        {user && user.role === 'ROLE_USER' && (
+          <Grid item xs={12} md={5}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                  <ShoppingCartIcon sx={{ mr: 1 }} />
+                  <Typography variant="h6">Record New Sale</Typography>
+                </Box>
+                <SaleForm />
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
 
         {/* Sales History */}
-        <Grid item xs={12} md={7}>
-          <Card sx={{ height: '100%' }}>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                Sales History
-              </Typography>
-              <SaleHistory />
-            </CardContent>
-          </Card>
-        </Grid>
+        {user && user.role === 'ROLE_ADMIN' && (
+          <Grid item xs={12} md={7}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  Sales History
+                </Typography>
+                <SaleHistory />
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
       </Grid>
     </Container>
   );

--- a/inventory-management-system-frontend/src/store.js
+++ b/inventory-management-system-frontend/src/store.js
@@ -3,6 +3,7 @@ import authReducer from './features/auth/authSlice';
 import productReducer from './features/products/productSlice';
 import saleReducer from './features/sales/saleSlice';
 import reportReducer from './features/reports/reportSlice';
+import categoryReducer from './features/categories/categorySlice';
 
 export const store = configureStore({
   reducer: {
@@ -10,5 +11,6 @@ export const store = configureStore({
     products: productReducer,
     sales: saleReducer,
     reports: reportReducer,
+    categories: categoryReducer,
   },
 });


### PR DESCRIPTION
This commit introduces user roles and permissions, and a new category management feature.

**User Roles and Permissions:**
- The backend now supports `ROLE_ADMIN` and `ROLE_USER` roles.
- New users are assigned the `ROLE_USER` role by default.
- API endpoints are secured based on user roles.
- The frontend UI is adapted to user roles, showing or hiding elements based on permissions.
- The sidebar navigation is also updated to reflect the user's role.

**Category Management:**
- A new category management feature has been added.
- The backend has a new `Category` model, repository, service, and controller.
- The category endpoints are restricted to admin users.
- The frontend has a new page for managing categories, with a Redux slice and service for state management.